### PR TITLE
feat(styles): remove style imports for v0.0.4 of aircore packages

### DIFF
--- a/javascript/index.html
+++ b/javascript/index.html
@@ -5,7 +5,6 @@
   <meta http-equiv='X-UA-Compatible' content='IE=edge'>
   <title>Aircore Media Panel - Basic HTML Example</title>
   <meta name='viewport' content='width=device-width, initial-scale=1'>
-  <link rel="stylesheet" href="https://unpkg.com/@aircore/aircore-media-panel/dist/index.css">
   <style>
     html, body {
       height: 100%;

--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aircore/react-sample",
+  "name": "@aircore/nextjs-sample",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/nextjs/styles/globals.css
+++ b/nextjs/styles/globals.css
@@ -1,5 +1,3 @@
-@import '@aircore/aircore-media-panel/dist/index.css';
-
 html,
 body {
   padding: 0;

--- a/react/package.json
+++ b/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-sample",
+  "name": "@aircore/react-sample",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/react/src/index.css
+++ b/react/src/index.css
@@ -1,5 +1,3 @@
-@import '@aircore/aircore-media-panel/dist/index.css';
-
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',

--- a/vue/src/App.vue
+++ b/vue/src/App.vue
@@ -4,13 +4,13 @@ import {
   createClientWithPublishableKey,
   type Client,
 } from "@aircore/aircore-panel-core";
-import { MediaPanel } from "@aircore/aircore-media-panel";
+import { MediaPanel, type MediaPanelType } from "@aircore/aircore-media-panel";
 
 const channelId = "YOUR_CHANNEL_ID";
 const userId = "YOUR_USER_ID" + Math.random();
 const publishableApiKey = import.meta.env.VITE_PUBLISHABLE_API_KEY as string; // get your api key on https://developer.aircore.io
 
-let myMediaPanel: ReturnType<typeof MediaPanel> | null = null;
+let myMediaPanel: MediaPanelType | null = null;
 let client: Client | null = null;
 
 onMounted(() => {

--- a/vue/src/assets/main.css
+++ b/vue/src/assets/main.css
@@ -1,4 +1,3 @@
-@import '@aircore/aircore-media-panel/dist/index.css';
 @import "./base.css";
 
 #app {


### PR DESCRIPTION
- For v0.0.4 we don't need to import styles, they are dynamically added in a <style> tag. 
- MediaPanelType is now available from @aircore/aircore-media-panel